### PR TITLE
Created build config and referenced it in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-The AZ-100 and AZ-101 certifications are being replaced by a new AZ-103 Microsoft Azure Administrator exam! You can read more about this announcement on Liberty Munson’s blog at https://www.microsoft.com/en-us/learning/community-blog-post.aspx?BlogId=8&Id=375217 
+# AZ-103 Microsoft Azure Administrator
+
+- **[Download Latest Student Handbook and AllFiles Content](../../releases/latest)**
+- **Are you a MCT?** - Have a look at our [GitHub User Guide for MCTs](https://microsoftlearning.github.io/MCT-User-Guide/)
+
+> The AZ-100 and AZ-101 certifications are being replaced by a new AZ-103 Microsoft Azure Administrator exam! You can read more about this announcement on Liberty Munson’s blog at https://www.microsoft.com/en-us/learning/community-blog-post.aspx?BlogId=8&Id=375217 
  
 To support the new exam, we introduce a new AZ-103 GitHub repository, starting on May 3 2019. At that time, all the AZ-100 and AZ-101 labs in their respective repositories will be moved to this repository. Those labs are being reused in AZ-103 and we would like to maintain only one repository. The AZ-100 and AZ-101 lab numbering system will be retained, so if you are still teaching the AZ-100 or AZ-101 courses you will be able to easily identify the labs. You will also be able to get the latest version of the labs, and submit any issues you find.
 
@@ -63,4 +68,4 @@ Note that the following labs will not be part of the AZ-103 course:
 We hope using this GitHub repository brings a sense of collaboration to the labs and improves the overall quality of the lab experience. 
 
 Regards,
-Azure Administrator Courseware Team
+*Azure Administrator Courseware Team*

--- a/_build.yml
+++ b/_build.yml
@@ -1,0 +1,36 @@
+name: '$(Date:yyyyMMdd)$(Rev:.rr)'
+jobs:
+  - job: build_markdown_content
+    displayName: 'Build Markdown Content'
+    workspace:
+      clean: all
+    pool:
+      vmImage: 'Ubuntu 16.04'
+    container:
+      image: 'microsoftlearning/markdown-build:latest'
+    steps:
+      - task: Bash@3
+        displayName: 'Build Content'
+        inputs:
+          targetType: inline
+          script: |
+            cp /{attribution.md,template.docx,package.json,package.js} .
+            npm install
+            node package.js --version $(Build.BuildNumber)
+      - task: GitHubRelease@0
+        displayName: 'Create GitHub Release'
+        inputs:
+          gitHubConnection: 'github-microsoftlearning-organization'
+          repositoryName: '$(Build.Repository.Name)'
+          tagSource: manual
+          tag: 'v$(Build.BuildNumber)'
+          title: 'Version $(Build.BuildNumber)'
+          releaseNotesSource: input
+          releaseNotes: '# Version $(Build.BuildNumber) Release'
+          assets: '$(Build.SourcesDirectory)/out/*.zip'
+          assetUploadMode: replace
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Output Files'
+        inputs:
+          pathtoPublish: '$(Build.SourcesDirectory)/out/'
+          artifactName: 'Lab Files'


### PR DESCRIPTION
This configuration file is necessary to have Azure DevOps automatically create ZIP files and DOCX files from your Markdown content