### PR TITLE
User risk policy config step excludes admin

### DIFF
--- a/Instructions/Labs/10 - Azure AD Identity Protection (az-101-04b).md
+++ b/Instructions/Labs/10 - Azure AD Identity Protection (az-101-04b).md
@@ -301,7 +301,7 @@ The main tasks for this exercise are as follows:
 
     - Assignments: 
 
-        - Users: **All users**
+        - Users: **All users** (be sure to exclude the current admin account to avoid getting locked out of the tenant)
 
         - Conditions:
 


### PR DESCRIPTION
Updated the recommended policy configuration, to exclude the admin account being used for this exercise, to ensure the user does not lock themselves out of their account. They should create a test user in their tenant, and try to simulate risky events using that test user.