### PR TITLE
typo from delete steps looks copied from prev mods

### DIFF
--- a/Instructions/Labs/06 - Azure Network Watcher (az-101-03b).md
+++ b/Instructions/Labs/06 - Azure Network Watcher (az-101-03b).md
@@ -534,7 +534,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to list all resource groups you created in this lab:
 
    ```sh
-   az group list --query "[?starts_with(name,'az1000')]".name --output tsv
+   az group list --query "[?starts_with(name,'az1010')]".name --output tsv
    ```
 
 1. Verify that the output contains only the resource groups you created in this lab. These groups will be deleted in the next task.
@@ -544,7 +544,7 @@ The main tasks for this exercise are as follows:
 1. At the **Cloud Shell** command prompt, type in the following command and press **Enter** to delete the resource groups you created in this lab
 
    ```sh
-   az group list --query "[?starts_with(name,'az1000')]".name --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
+   az group list --query "[?starts_with(name,'az1010')]".name --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
    ```
 
 1. Close the **Cloud Shell** prompt at the bottom of the portal.


### PR DESCRIPTION
The same delete section that is used in previous modules appears to be copied here, however; the module earlier creates resource groups that start with "az1010" not "az1000" as in previous modules.